### PR TITLE
Fixes JSON parsing error in `input.query` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ curl \
  --json "
   {
    'yql': 'select * from vectors where {targetHits:10}nearestNeighbor(vector, q)',
-   input.query(q)': '$query' 
+   'input.query(q)': '$query' 
   }" \
  https://vector-search.<tenant-name>.aws-us-east-1c.dev.z.vespa-app.cloud/search/
  ```
@@ -300,7 +300,7 @@ curl \
  --json "
   {
    'yql': 'select * from vectors where {targetHits:10,approximate:false}nearestNeighbor(vector, q)',
-   input.query(q)': '$query' 
+   'input.query(q)': '$query' 
   }" \
  https://vector-search.<tenant-name>.aws-us-east-1c.dev.z.vespa-app.cloud/search/
  ```
@@ -314,7 +314,7 @@ curl \
  --json "
   {
    'yql': 'select * from vectors where {targetHits:10}nearestNeighbor(vector, q) and tags contains \"tag1\"',
-   input.query(q)': '$query' 
+   'input.query(q)': '$query' 
   }" \
  https://vector-search.<tenant-name>.aws-us-east-1c.dev.z.vespa-app.cloud/search/
  ```


### PR DESCRIPTION
Fixed this issue

```
--json "
  {
   'yql': 'select * from vectors where {targetHits:10} nearestNeighbor(vector, q)',
   input.query(q)': '$query'
  }" \
 https://a901b714.aa994632.z.vespa-app.cloud/search/
{"root":{"id":"toplevel","relevance":1.0,"fields":{"totalCount":0},"errors":[{"code":3,"summary":"Illegal query","message":"Json parse error.: Unexpected character ('i' (code 105)): was expecting double-quote to start field name\n at [Source: (byte[])\"\n  {\n   'yql': 'select * from vectors where {targetHits:10} nearestNeighbor(vector, q)',\n   input.query(q)': '[0.2913021147251129,0.5057677030563354,0.5451035499572754,0.27675727009773254,0.10927736759185791,0.06706570088863373,0.1770867556333542,0.7996796369552612,0.6307869553565979,0.7204529047012329,0.13946707546710968,0.8562200665473938,0.3066636025905609,0.1463921070098877,0.8984076976776123,0.6209235191345215,0.47249022126197815,0.09817588329315186,0.17768551409244537,0.8677831292152405,0.\"[truncated 14419 bytes]; line: 4, column: 5]"}]}}%```