### PR TITLE
chore: create .vespaignore

### DIFF
--- a/.vespaignore
+++ b/.vespaignore
@@ -1,0 +1,10 @@
+# no hidden files and git specifics
+.DS_Store
+.git/
+.github/
+
+# Skip sources and text files
+README.md
+
+# Scripts, not part of the app.
+*.py


### PR DESCRIPTION
## What

Creates a useful `.vespaignore` file to specify which files and directories should be ignored. The most important changes are:

* Added rules to ignore hidden files and Git specifics such as `.DS_Store`, `.git/`, and `.github/`.
* Added a rule to skip the `README.md` file.
* Added a rule to ignore Python script files with the extension `.py`.

## Why

Those files aren't needed in the application package, and especially the git repo can just make the package larger without reason.