### PR TITLE
Disable push trigger in deploy-vector-search workflow

### DIFF
--- a/.github/workflows/deploy-vector-search.yaml
+++ b/.github/workflows/deploy-vector-search.yaml
@@ -5,8 +5,8 @@
 name: Deploy vector-search to Vespa Cloud
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
+  # push:
+  #   branches: [ main ]
   #schedule:
   #   5:40 UTC daily 
   #   - cron: '40 5 * * *'


### PR DESCRIPTION
- save some resources, we can deploy on demand - currently deployed to four zones